### PR TITLE
add pip install einops

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ cd templates/2d_diffusion && python experiment.py --out_dir run_0 && python plot
 
 ```bash
 # Set up Grokking baseline run
+pip install einops
 cd templates/grokking && python experiment.py --out_dir run_0 && python plot.py
 ```
 


### PR DESCRIPTION
You need to install `einops` package to run `templates/grokking/experiment.py`
So I added the instruction to install einops in readme.