### PR TITLE
Add fallback to try parsing json when markers not found

### DIFF
--- a/ai_scientist/llm.py
+++ b/ai_scientist/llm.py
@@ -223,16 +223,20 @@ def extract_json_between_markers(llm_output):
     if start_index != -1:
         start_index += len(json_start_marker)  # Move past the marker
         end_index = llm_output.find(json_end_marker, start_index)
+        if end_index == -1:
+            # Extract the JSON string
+            json_string = llm_output[start_index:end_index].strip()
+            try:
+                parsed_json = json.loads(json_string)
+                return parsed_json
+            except json.JSONDecodeError:
+                return None  # Invalid JSON format
+        else:
+            return None  # End marker not found
+    # Fallback: Attempt to parse the entire llm_output as JSON
     else:
-        return None  # JSON markers not found
-
-    if end_index == -1:
-        return None  # End marker not found
-
-    # Extract the JSON string
-    json_string = llm_output[start_index:end_index].strip()
-    try:
-        parsed_json = json.loads(json_string)
-        return parsed_json
-    except json.JSONDecodeError:
-        return None  # Invalid JSON format
+        try:
+            parsed_json = json.loads(llm_output)
+            return parsed_json
+        except json.JSONDecodeError:
+            return None  # Invalid JSON format or markers not found


### PR DESCRIPTION
Fallback for valid json missing markers per #53. 

The original logic for finding and extracting json between markers is retained, but if no start marker is found, the function attempts to parse the entire llm_output as json. This change allows the function to handle both marker-enclosed json and raw json input.