### PR TITLE
Azure OpenAI integration, SSL Verification on/off toggle, and retry scheduling update

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ We support a wide variety of models including open-weight and API-only models. I
 
 By default, this uses the `OPENAI_API_KEY` environment variable.
 
+##### OpenAI Models via Azure OpenAI Service
+
+This setup uses the OpenAI API directly, so no additional packages are required.
+
+Three environment variables are necessary: `AZURE_API_KEY`, `AZURE_API_BASE`, and `AZURE_API_VERSION`. These follow the naming convention specified in [Aider's documentation](https://aider.chat/docs/llms/azure.html).
+
+When accessing models via Azure OpenAI Service, the deployment name is used instead of the underlying model name in API calls. Ensure that your deployment is named like a standard OpenAI model (e.g., `gpt-4o-2024-08-06`). For more information, check [this link](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/switching-endpoints).
+
+If bypassing SSL certificate verification is required, add `--no-verify-ssl` in the argument list when executing your Python code.
+
 #### Anthropic API (Claude Sonnet 3.5)
 
 By default, this uses the `ANTHROPIC_API_KEY` environment variable.

--- a/ai_scientist/perform_writeup.py
+++ b/ai_scientist/perform_writeup.py
@@ -256,7 +256,7 @@ RESPONSE:
 ```
 
 In <THOUGHT>, first briefly reason over the paper and identify where citations should be added.
-If there are more citations needed, add "No more citations needed" to your thoughts.
+If no more citations are needed, add "No more citations needed" to your thoughts.
 Do not add "No more citations needed" if you are adding citations this round.
 
 In <JSON>, respond in JSON format with the following fields:
@@ -533,16 +533,33 @@ if __name__ == "__main__":
             "bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
             "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
             "bedrock/anthropic.claude-3-haiku-20240307-v1:0",
-            "bedrock/anthropic.claude-3-opus-20240229-v1:0"
+            "bedrock/anthropic.claude-3-opus-20240229-v1:0",
             # Anthropic Claude models Vertex AI
             "vertex_ai/claude-3-opus@20240229",
             "vertex_ai/claude-3-5-sonnet@20240620",
             "vertex_ai/claude-3-sonnet@20240229",
-            "vertex_ai/claude-3-haiku@20240307"
+            "vertex_ai/claude-3-haiku@20240307",
+            # OpenAI models via Azure
+            "azure/gpt-4o-2024-08-06",
+            "azure/gpt-4o-2024-05-13",
         ],
         help="Model to use for AI Scientist.",
     )
+    parser.add_argument(
+        "--verify-ssl", # implemented only for Azure OpenAI API
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Verify SSL certificate when connecting to model API (default: True)", 
+    )
+
     args = parser.parse_args()
+    # [--no-verify-ssl] Disable SSL verification for aider's litellm calls
+    if not args.verify_ssl:
+        from aider.llm import litellm
+        import httpx
+        litellm._load_litellm()
+        litellm._lazy_module.client_session = httpx.Client(verify=False)
+    # Create client
     if args.model == "claude-3-5-sonnet-20240620":
         import anthropic
 
@@ -571,6 +588,19 @@ if __name__ == "__main__":
         print(f"Using OpenAI API with model {args.model}.")
         client_model = "gpt-4o-2024-05-13"
         client = openai.OpenAI()
+    elif args.model.startswith("azure") and "gpt" in args.model:
+        import openai
+
+        # Expects: azure/<DEPLOYMENT_NAME>
+        client_model = args.model.split("/")[-1]
+
+        print(f"Using Azure with model {client_model}.")
+        client = openai.AzureOpenAI(
+                api_key=os.getenv("AZURE_API_KEY"),
+                api_version=os.getenv("AZURE_API_VERSION"),
+                azure_endpoint=os.getenv("AZURE_API_BASE"),
+                http_client=httpx.Client(verify=False) if not args.verify_ssl else None,
+            )
     elif args.model == "deepseek-coder-v2-0724":
         import openai
 

--- a/launch_scientist.py
+++ b/launch_scientist.py
@@ -56,14 +56,24 @@ def parse_arguments():
             "bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
             "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
             "bedrock/anthropic.claude-3-haiku-20240307-v1:0",
-            "bedrock/anthropic.claude-3-opus-20240229-v1:0"
+            "bedrock/anthropic.claude-3-opus-20240229-v1:0",
             # Anthropic Claude models Vertex AI
             "vertex_ai/claude-3-opus@20240229",
             "vertex_ai/claude-3-5-sonnet@20240620",
             "vertex_ai/claude-3-sonnet@20240229",
             "vertex_ai/claude-3-haiku@20240307",
+            # OpenAI models via Azure
+            "azure/gpt-4o-2024-08-06",
+            "azure/gpt-4o-2024-05-13",
         ],
         help="Model to use for AI Scientist.",
+    )
+
+    parser.add_argument(
+        "--verify-ssl", # implemented only for Azure OpenAI API
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Verify SSL certificate when connecting to model API (default: True)", 
     )
     parser.add_argument(
         "--writeup",
@@ -310,6 +320,13 @@ if __name__ == "__main__":
 
     print(f"Using GPUs: {available_gpus}")
 
+    # [--no-verify-ssl] Disable SSL verification for aider's litellm calls
+    if not args.verify_ssl:
+        from aider.llm import litellm
+        import httpx
+        litellm._load_litellm()
+        litellm._lazy_module.client_session = httpx.Client(verify=False)
+
     # Create client
     if args.model == "claude-3-5-sonnet-20240620":
         import anthropic
@@ -343,6 +360,19 @@ if __name__ == "__main__":
         print(f"Using OpenAI API with model {args.model}.")
         client_model = "gpt-4o-2024-05-13"
         client = openai.OpenAI()
+    elif args.model.startswith("azure") and "gpt" in args.model:
+        import openai
+
+        # Expects: azure/<DEPLOYMENT_NAME>
+        client_model = args.model.split("/")[-1]
+
+        print(f"Using Azure with model {client_model}.")
+        client = openai.AzureOpenAI(
+                api_key=os.getenv("AZURE_API_KEY"),
+                api_version=os.getenv("AZURE_API_VERSION"),
+                azure_endpoint=os.getenv("AZURE_API_BASE"),
+                http_client=httpx.Client(verify=False) if not args.verify_ssl else None,
+            )
     elif args.model == "deepseek-coder-v2-0724":
         import openai
 


### PR DESCRIPTION
This PR includes updates across multiple files to add Azure OpenAI support. I have tested the changes with both `launch_scientist.py` and individual command-line calls for `generate_ideas.py`, `perform_writeup.py`, and `iclr_analysis.py`. Aider integration has been verified, and everything appears to be functioning correctly.

### Major Updates:
- **Azure OpenAI Service Integration**: Added support for OpenAI models via Azure (currently only `gpt4o` models). Other [Azure-supported models](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models) can be added down the road.
- **SSL Certificate Verification**: Introduced the `--no-verify-ssl` argument to disable SSL certificate verification for Azure OpenAI models. While this is currently implemented only for Azure, it can be extended to other APIs (OpenAI and Anthropic) since they all use `httpx` clients.

### Minor Updates:
- **Retry Scheduling**: Adjusted retry strategy for Semantic Scholar API queries (`search_for_paper` in `generate_ideas.py`). Switched from exponential backoff to constant with jitter for improved efficiency, avoiding excessive hang time.