### PR TITLE
update DeepSeek-V3 and DeepSeek-R1

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ export VERTEXAI_LOCATION="REGION"         # for Aider/LiteLLM call
 export VERTEXAI_PROJECT="PROJECT_ID"      # for Aider/LiteLLM call
 ```
 
-#### DeepSeek API (DeepSeek-Coder-V2)
+#### DeepSeek API (DeepSeek-V3)
 
 By default, this uses the `DEEPSEEK_API_KEY` environment variable.
 
@@ -337,7 +337,7 @@ The AI Scientist finishes an idea with a success rate that depends on the templa
 
 **What is the cost of each idea generated?**
 
-Typically less than $15 per paper with Claude Sonnet 3.5. We recommend DeepSeek Coder V2 for a much more cost-effective approach. A good place to look for new models is the [Aider leaderboard](https://aider.chat/docs/leaderboards/).
+Typically less than $15 per paper with Claude Sonnet 3.5. We recommend DeepSeek-V3 for a much more cost-effective approach. A good place to look for new models is the [Aider leaderboard](https://aider.chat/docs/leaderboards/).
 
 **How do I change the base conference format associated with the write-ups?**
 


### PR DESCRIPTION
DeepSeek V3 is out for a while now, so just updating the docs:

![image](https://github.com/user-attachments/assets/db1be102-59f4-422c-8afa-7c277eea0aa2)



cf. https://api-docs.deepseek.com/