### PR TITLE
Added checks for pdflatex and chktex

### DIFF
--- a/launch_scientist.py
+++ b/launch_scientist.py
@@ -98,6 +98,27 @@ def get_available_gpus(gpu_ids=None):
     return list(range(torch.cuda.device_count()))
 
 
+def check_latex_dependencies():
+    """
+    Check if required LaTeX dependencies are installed on the system.
+    Returns True if all dependencies are found, False otherwise.
+    """
+    import shutil
+    import sys
+
+    required_dependencies = ['pdflatex', 'chktex']
+    missing_deps = []
+
+    for dep in required_dependencies:
+        if shutil.which(dep) is None:
+            missing_deps.append(dep)
+    
+    if missing_deps:
+        print("Error: Required LaTeX dependencies not found:", file=sys.stderr)
+        return False
+    
+    return True
+    
 def worker(
         queue,
         base_dir,
@@ -303,6 +324,10 @@ if __name__ == "__main__":
         args.parallel = len(available_gpus)
 
     print(f"Using GPUs: {available_gpus}")
+
+    # Check LaTeX dependencies before proceeding
+    if args.writeup == "latex" and not check_latex_dependencies():
+        sys.exit(1)
 
     # Create client
     client, client_model = create_client(args.model)


### PR DESCRIPTION
If you don't download / download fails for certain latex packages with:

sudo apt-get install texlive-full

The launch_scientist.py will still proceed through the entire generation process (draining ~$10-15 in API credits), until the last step where it throws an error for missing chktex and does not save the generated file. See below:

Tokens: 17k sent, 329 received. Cost: $0.09 message, $2.37 session. Applied edit to latex/template.tex
/bin/sh: 1: chktex: not found
GENERATING LATEX
Failed to perform writeup: [Errno 2] No such file or directory: 'pdflatex' FINISHED IDEA
Completed idea: alternative_noise_schedules, Success: False All ideas evaluated.

Added a simple check in launch_scientist.py to confirm chktex and pdflatex distributions are present before proceeding with experiments.