### PR TITLE
Add google-generativeai to LLM API imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ anthropic
 aider-chat
 backoff
 openai
+google-generativeai
 # Viz
 matplotlib
 pypdf


### PR DESCRIPTION
You have to ```pip install google-generativeai``` in order for launch_scientist.py to work out of box:

```
Traceback (most recent call last):
  File "/home/ubuntu/tester/AI-Scientist/launch_scientist.py", line 16, in <module>
    from ai_scientist.generate_ideas import generate_ideas, check_idea_novelty
  File "/home/ubuntu/tester/AI-Scientist/ai_scientist/generate_ideas.py", line 10, in <module>
    from ai_scientist.llm import get_response_from_llm, extract_json_between_markers, create_client, AVAILABLE_LLMS
  File "/home/ubuntu/tester/AI-Scientist/ai_scientist/llm.py", line 8, in <module>
    import google.generativeai as genai
ModuleNotFoundError: No module named 'google.generativeai'
```