### PR TITLE
Add support for "o1-2024-12-17" model in `get_response_from_llm`

### DIFF
--- a/ai_scientist/llm.py
+++ b/ai_scientist/llm.py
@@ -190,7 +190,11 @@ def get_response_from_llm(
         )
         content = response.choices[0].message.content
         new_msg_history = new_msg_history + [{"role": "assistant", "content": content}]
-    elif model in ["o1-preview-2024-09-12", "o1-mini-2024-09-12"]:
+    elif model in [
+        "o1-preview-2024-09-12", 
+        "o1-mini-2024-09-12",
+        "o1-2024-12-17",
+    ]:
         new_msg_history = msg_history + [{"role": "user", "content": msg}]
         response = client.chat.completions.create(
             model=model,


### PR DESCRIPTION
The "o1-2024-12-17" model is listed in `AVAILABLE_LLMS` but lacks implementation in `get_response_from_llm`, causing ValueError when attempting to use it. This commit adds the missing model to the existing o1 models conditional block.